### PR TITLE
Fix parse error in Markdown.sublime-settings

### DIFF
--- a/prefs/Ext/Markdown.sublime-settings
+++ b/prefs/Ext/Markdown.sublime-settings
@@ -6,6 +6,6 @@
     "draw_centered": false, // Centers the column in the window
     "draw_indent_guides": false,
     "trim_trailing_white_space_on_save": false,
-    "word_wrap": false,
+    "word_wrap": false
     // "wrap_width": 80  // Sets the # of characters per line
 }


### PR DESCRIPTION
The trailing comma introduced in https://github.com/lioshi/lioshiScheme/commit/f00d5eb6a810b787d092df3d79f4d76077fa786b throws a parse error when trying to load Sublime Text:

```
Error trying to parse settings: Trailing comma before closing backets in .../markdown.sublime-settings:11:1
```
